### PR TITLE
fix: Update Claude settings hooks to new format

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -24,13 +24,19 @@
     }
   },
   "hooks": {
-    "router": {
-      "UserPromptSubmit": {
-        "match": "/research|/synthesize|/know|/explore",
-        "script": ".claude/hooks/router.sh",
-        "description": "Simple command routing"
+    "UserPromptSubmit": [
+      {
+        "matcher": {
+          "prompts": ["/research", "/synthesize", "/know", "/explore"]
+        },
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/router.sh"
+          }
+        ]
       }
-    }
+    ]
   },
   "permissions": {
     "tools": {


### PR DESCRIPTION
## Summary
- Fixed Claude Code settings validation error by migrating hooks configuration to new format
- Ensures compatibility with latest Claude Code hook specification

## Changes
- Migrated hooks from deprecated object format to required array format  
- Updated UserPromptSubmit hook to use proper matcher structure with prompts array
- Fixed command execution format for router.sh hook

## Problem Solved
Resolves validation error: `hooks.router: Expected array, but received object`

## Testing
The settings file now passes Claude Code validation and hooks will properly trigger for commands:
- `/research`
- `/synthesize`
- `/know`
- `/explore`

## References
- [Claude Code Hooks Documentation](https://docs.anthropic.com/en/docs/claude-code/hooks)

🤖 Generated with [Claude Code](https://claude.ai/code)